### PR TITLE
[BE] Feat #21: 후기 리액션 기능 구현

### DIFF
--- a/backend/src/main/java/com/ggums/ggumtle/controller/ReviewController.java
+++ b/backend/src/main/java/com/ggums/ggumtle/controller/ReviewController.java
@@ -1,7 +1,9 @@
 package com.ggums.ggumtle.controller;
 
 import com.ggums.ggumtle.common.response.Response;
-import com.ggums.ggumtle.dto.request.ReviewRequestDto;
+import com.ggums.ggumtle.dto.request.PutReviewRequestDto;
+import com.ggums.ggumtle.dto.request.ReviewReactionRequestDto;
+import com.ggums.ggumtle.dto.request.PostReviewRequestDto;
 import com.ggums.ggumtle.entity.User;
 import com.ggums.ggumtle.service.ReviewService;
 import lombok.RequiredArgsConstructor;
@@ -17,13 +19,13 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping
-    public Long postReview(@AuthenticationPrincipal User user, @RequestBody ReviewRequestDto requestDto) {
-        return reviewService.postReview(user, requestDto);
+    public Response postReview(@AuthenticationPrincipal User user, @RequestBody PostReviewRequestDto requestDto) {
+        return new Response("review_id", reviewService.postReview(user, requestDto));
     }
 
     @PostMapping("/image")
-    public String postImage(@RequestParam final MultipartFile image) {
-        return reviewService.postImage(image);
+    public Response postImage(@RequestParam final MultipartFile image) {
+        return new Response("image_url", reviewService.postImage(image));
     }
 
     @GetMapping("/{reviewId}")
@@ -32,12 +34,22 @@ public class ReviewController {
     }
 
     @PutMapping("/{reviewId}")
-    public Response putReview(@AuthenticationPrincipal User user, @PathVariable Long reviewId, @RequestBody ReviewRequestDto requestDto) {
+    public Response putReview(@AuthenticationPrincipal User user, @PathVariable Long reviewId, @RequestBody PutReviewRequestDto requestDto) {
         return new Response("review_id", reviewService.putReview(user, reviewId, requestDto));
     }
 
     @DeleteMapping("/{reviewId}")
     public Response deleteReview(@AuthenticationPrincipal User user, @PathVariable Long reviewId) {
         return new Response("message", reviewService.deleteReview(user, reviewId));
+    }
+
+    @PostMapping("/{reviewId}/reaction")
+    public Response postReviewReaction(@AuthenticationPrincipal User user, @PathVariable Long reviewId, @RequestBody ReviewReactionRequestDto requestDto) {
+        return new Response("myReaction", reviewService.postReviewReaction(user, reviewId, requestDto));
+    }
+
+    @GetMapping("/{reviewId}/reaction")
+    public Response getReviewReaction(@AuthenticationPrincipal User user, @PathVariable Long reviewId) {
+        return new Response("review_reactions", reviewService.getReviewReaction(user, reviewId));
     }
 }

--- a/backend/src/main/java/com/ggums/ggumtle/dto/request/PostReviewRequestDto.java
+++ b/backend/src/main/java/com/ggums/ggumtle/dto/request/PostReviewRequestDto.java
@@ -1,0 +1,10 @@
+package com.ggums.ggumtle.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class PostReviewRequestDto {
+    private Long bucketId;
+    private String title;
+    private String context;
+}

--- a/backend/src/main/java/com/ggums/ggumtle/dto/request/PutReviewRequestDto.java
+++ b/backend/src/main/java/com/ggums/ggumtle/dto/request/PutReviewRequestDto.java
@@ -3,7 +3,7 @@ package com.ggums.ggumtle.dto.request;
 import lombok.Getter;
 
 @Getter
-public class ReviewRequestDto {
+public class PutReviewRequestDto {
     private String title;
     private String context;
 }

--- a/backend/src/main/java/com/ggums/ggumtle/dto/request/ReviewReactionRequestDto.java
+++ b/backend/src/main/java/com/ggums/ggumtle/dto/request/ReviewReactionRequestDto.java
@@ -1,0 +1,8 @@
+package com.ggums.ggumtle.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ReviewReactionRequestDto {
+    private String reaction;
+}

--- a/backend/src/main/java/com/ggums/ggumtle/dto/response/ReviewReactionResponseDto.java
+++ b/backend/src/main/java/com/ggums/ggumtle/dto/response/ReviewReactionResponseDto.java
@@ -1,0 +1,13 @@
+package com.ggums.ggumtle.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class ReviewReactionResponseDto {
+    private Map<String, Integer> reactionCounts;
+    private String myReaction;
+}

--- a/backend/src/main/java/com/ggums/ggumtle/dto/response/ReviewResponseDto.java
+++ b/backend/src/main/java/com/ggums/ggumtle/dto/response/ReviewResponseDto.java
@@ -11,9 +11,20 @@ import java.util.Map;
 @Builder
 public class ReviewResponseDto {
 
+    // bucket
+    private Long bucketId;
+    private String bucketTitle;
+    private long daysSinceDream;
+
+    // user
+    private Long writerId;
+    private String writerProfileImage;
+    private String writerNickname;
+
+    // review
     private String reviewTitle;
     private String reviewContext;
     private LocalDateTime reviewCreatedDate;
     private LocalDateTime reviewUpdatedDate;
-
+    private List<String> categories;
 }

--- a/backend/src/main/java/com/ggums/ggumtle/entity/Review.java
+++ b/backend/src/main/java/com/ggums/ggumtle/entity/Review.java
@@ -17,9 +17,16 @@ public class Review extends BaseTime {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OneToOne
+    @JoinColumn(name = "bucket_id")
+    private Bucket bucket;
+
     private String title;
 
     @Lob
     @Column(columnDefinition = "LONGTEXT")
     private String context;
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ReviewReaction> reviewReactions = new ArrayList<>();
 }

--- a/backend/src/main/java/com/ggums/ggumtle/entity/ReviewReaction.java
+++ b/backend/src/main/java/com/ggums/ggumtle/entity/ReviewReaction.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/ggums/ggumtle/repository/ReviewReactionRepository.java
+++ b/backend/src/main/java/com/ggums/ggumtle/repository/ReviewReactionRepository.java
@@ -1,0 +1,9 @@
+package com.ggums.ggumtle.repository;
+
+import com.ggums.ggumtle.entity.ReviewReaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewReactionRepository extends JpaRepository<ReviewReaction, Long> {
+}

--- a/backend/src/main/java/com/ggums/ggumtle/service/ReviewService.java
+++ b/backend/src/main/java/com/ggums/ggumtle/service/ReviewService.java
@@ -2,40 +2,60 @@ package com.ggums.ggumtle.service;
 
 import com.ggums.ggumtle.common.exception.CustomException;
 import com.ggums.ggumtle.common.exception.ExceptionType;
-import com.ggums.ggumtle.dto.request.ReviewRequestDto;
+import com.ggums.ggumtle.dto.request.PutReviewRequestDto;
+import com.ggums.ggumtle.dto.request.ReviewReactionRequestDto;
+import com.ggums.ggumtle.dto.request.PostReviewRequestDto;
+import com.ggums.ggumtle.dto.response.ReviewReactionResponseDto;
 import com.ggums.ggumtle.dto.response.ReviewResponseDto;
-import com.ggums.ggumtle.entity.Review;
-import com.ggums.ggumtle.entity.User;
+import com.ggums.ggumtle.entity.*;
+import com.ggums.ggumtle.repository.BucketRepository;
+import com.ggums.ggumtle.repository.ReviewReactionRepository;
 import com.ggums.ggumtle.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final BucketRepository bucketRepository;
+    private final ReviewReactionRepository reviewReactionRepository;
+
+    @Value("${spring.web.baseUrl}")
+    private String baseUrl;
 
     private final String basicDir = Paths.get(System.getProperty("user.dir")).getParent().toString();
     private final String uploadDir = Paths.get(basicDir, "image", "reviewImage").toString();
 
     @Transactional
-    public Long postReview(User user, ReviewRequestDto requestDto) {
+    public Long postReview(User user, PostReviewRequestDto requestDto) {
+
+        Bucket bucket = bucketRepository.findById(requestDto.getBucketId())
+                .orElseThrow(() -> new CustomException(ExceptionType.BUCKET_NOT_FOUND));
+
+        // 버킷의 주인만 후기를 작성할 수 있다.
+        if (!bucket.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ExceptionType.NOT_VALID_USER);
+        }
+
         Review review = Review.builder()
+                .bucket(bucket)
                 .title(requestDto.getTitle())
                 .context(requestDto.getContext())
                 .build();
-        
+
         Review savedReview = reviewRepository.save(review);
         return savedReview.getId();
     }
@@ -59,7 +79,7 @@ public class ReviewService {
 
         // uploadDir에 해당되는 디렉터리가 없으면, uploadDir에 포함되는 전체 디렉터리 생성
         File dir = new File(uploadDir);
-        if (dir.exists() == false) {
+        if (!dir.exists()) {
             dir.mkdirs();
         }
 
@@ -67,7 +87,7 @@ public class ReviewService {
             // 파일 저장 (write to disk)
             File uploadFile = new File(fileFullPath);
             image.transferTo(uploadFile);
-            return "image/reviewImage/" + saveFilename;
+            return baseUrl + "/image/reviewImage/" + saveFilename;
         } catch (IOException e) {
             // transferTo()에서 IOE 발생할 수 있음
             throw new RuntimeException(e);
@@ -79,31 +99,137 @@ public class ReviewService {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ExceptionType.REVIEW_NOT_FOUND));
 
+        Bucket bucket = review.getBucket();
+        User writer = bucket.getUser();
+
+        // 후기 조회 불가능한 경우 : 버킷 비공개 && 본인의 버킷(후기)이 아님
+        if (bucket.getIsPrivate() && !writer.getId().equals(user.getId())) {
+            throw new CustomException(ExceptionType.REVIEW_NOT_VALID);
+        }
+
+        LocalDate createdDate = bucket.getCreatedDate().toLocalDate();
+        LocalDate achievementDate = bucket.getAchievementDate();
+        long daysSinceDream = ChronoUnit.DAYS.between(createdDate, achievementDate);
+
+        List<String> categories = new ArrayList<>();
+        for (Interest interest : bucket.getInterests()) {
+            categories.add(interest.getName());
+        }
+
         return ReviewResponseDto.builder()
+                .bucketId(bucket.getId())
+                .bucketTitle(bucket.getTitle())
+                .daysSinceDream(daysSinceDream)
+                .writerId(writer.getId())
+                .writerProfileImage(writer.getUserProfileImage())
+                .writerNickname(writer.getUserNickname())
                 .reviewTitle(review.getTitle())
                 .reviewContext(review.getContext())
                 .reviewCreatedDate(review.getCreatedDate())
                 .reviewUpdatedDate(review.getUpdatedDate())
+                .categories(categories)
                 .build();
     }
 
     @Transactional
-    public Long putReview(User user, Long reviewId, ReviewRequestDto requestDto) {
+    public Long putReview(User user, Long reviewId, PutReviewRequestDto requestDto) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ExceptionType.REVIEW_NOT_FOUND));
+
+        // 후기의 작성자만 후기를 수정할 수 있다.
+        if (!review.getBucket().getUser().getId().equals(user.getId())) {
+            throw new CustomException(ExceptionType.NOT_VALID_USER);
+        }
 
         review.setTitle(requestDto.getTitle());
         review.setContext(requestDto.getContext());
 
+        reviewRepository.save(review);
+
         return review.getId();
     }
 
+    @Transactional
     public String deleteReview(User user, Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ExceptionType.REVIEW_NOT_FOUND));
 
+        // 후기의 작성자만 후기를 삭제할 수 있다.
+        if (!review.getBucket().getUser().getId().equals(user.getId())) {
+            throw new CustomException(ExceptionType.NOT_VALID_USER);
+        }
+
         reviewRepository.delete(review);
 
         return "삭제를 완료하였습니다.";
+    }
+
+    @Transactional
+    public String postReviewReaction(User user, Long reviewId, ReviewReactionRequestDto requestDto) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(ExceptionType.REVIEW_NOT_FOUND));
+
+        String reaction = requestDto.getReaction();
+
+        List<ReviewReaction> myReviewReactions = review.getReviewReactions().stream()
+                .filter(reviewReaction -> reviewReaction.getUser().getId().equals(user.getId()))
+                .collect(Collectors.toList());
+
+        // [POST] 해당 후기에 남긴 리액션이 없는 경우
+        if (myReviewReactions.isEmpty()) {
+            ReviewReaction newReviewReaction = ReviewReaction.builder()
+                    .user(user)
+                    .review(review)
+                    .reaction(reaction)
+                    .build();
+            reviewReactionRepository.save(newReviewReaction);
+            review.getReviewReactions().add(newReviewReaction);
+            return reaction;
+        }
+        // 해당 후기에 이미 남긴 리액션이 있는 경우
+        else {
+            ReviewReaction myReviewReaction = myReviewReactions.get(0);
+
+            // [DELETE] 해당 리액션을 취소하려는 경우
+            if (reaction.equals(myReviewReaction.getReaction())) {
+                reviewReactionRepository.delete(myReviewReaction);
+                review.getReviewReactions().remove(myReviewReaction);
+                return null;
+            }
+            // [PUT] 해당 리액션을 수정하려는 경우
+            else {
+                myReviewReaction.setReaction(reaction);
+                reviewReactionRepository.save(myReviewReaction);
+                return reaction;
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewReactionResponseDto getReviewReaction(User user, Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(ExceptionType.REVIEW_NOT_FOUND));
+
+        // 후기가 비공개인 경우 작성자만 열람할 수 있다.
+        if (review.getBucket().getIsPrivate() && !review.getBucket().getUser().getId().equals(user.getId())) {
+            throw new CustomException(ExceptionType.REVIEW_NOT_VALID);
+        }
+
+        List<ReviewReaction> reactionList = review.getReviewReactions();
+        Map<String, Integer> reactionCounts = new HashMap<>();
+        String myReaction = null;
+        for (ReviewReaction reaction : reactionList) {
+            String reactionType = reaction.getReaction();
+            reactionCounts.put(reactionType, reactionCounts.getOrDefault(reactionType, 0) + 1);
+
+            if (reaction.getUser().getId().equals(user.getId())) {
+                myReaction = reactionType;
+            }
+        }
+
+        return ReviewReactionResponseDto.builder()
+                .reactionCounts(reactionCounts)
+                .myReaction(myReaction)
+                .build();
     }
 }

--- a/backend/src/main/resources/data-mysql.sql
+++ b/backend/src/main/resources/data-mysql.sql
@@ -3,7 +3,7 @@ INSERT INTO user (user_nickname, user_profile_image, birth_date, gender, deleted
 VALUES ('nickname1', 'profile_image1.jpg', '1990-01-01', 'Male', NULL, NOW(), NOW());
 
 -- Dummy Review for development
-insert into review (title, context, created_date, updated_date)
-values('this is a title.',
+insert into review (title, bucket_id, context, created_date, updated_date)
+values('this is a title.', null,
        '<h1>Heading1</h1><h2>Heading2</h2><h3>Heading3</h3><p><strong>bold</strong></p><p><em>italic</em></p><p><br></p><p><del>strike</del></p><div contenteditable="false"><hr></div><p>line</p><blockquote><p>quote</p></blockquote><ul><li><p>ul</p></li><li><p>ul2</p></li></ul><ol><li><p>ol</p></li><li><p>ol2</p></li></ol><ul><li class="task-list-item" data-task="true"><p>to do</p></li><li class="task-list-item" data-task="true"><p>to do 2</p></li></ul><table><thead><tr><th><p>c1</p></th><th><p>c2</p></th><th><p>c3</p></th><th><p>c4</p></th></tr></thead><tbody><tr><td><p>this</p></td><td><p>is</p></td><td><p>a</p></td><td><p>table.</p></td></tr></tbody></table><p><img src="/tui-editor/image-print?filename=9237233c01394213a26fcf432f889c99.jpg" alt="image alt attribute" contenteditable="false"><br></p><p><a href="https://www.naver.com/">This is a link to naver.</a></p><p><br></p><p><code data-backticks="1">print(12345)</code></p><div data-language="text" class="toastui-editor-ww-code-block"><pre><code>A, B = map(int, input().split())print(A+B)</code></pre></div>',
        now(), now());

--- a/backend/src/main/resources/schema-mysql.sql
+++ b/backend/src/main/resources/schema-mysql.sql
@@ -11,16 +11,6 @@ CREATE TABLE user (
     PRIMARY KEY (id)
 );
 
--- Review Table
-create table review (
-    id           bigint not null auto_increment,
-    title        VARCHAR(255),
-    context      LONGTEXT,
-    created_date datetime(6) not null,
-    updated_date datetime(6) not null,
-    primary key (id)
-);
-
 -- Bucket Table
 CREATE TABLE bucket (
     achievement_date DATE,
@@ -56,4 +46,27 @@ CREATE TABLE reactions (
     PRIMARY KEY (id),
     FOREIGN KEY (bucket_id) REFERENCES bucket(id),
     FOREIGN KEY (user_id) REFERENCES user(id)
+);
+
+-- Review Table
+create table review (
+    id           bigint not null auto_increment,
+    title        VARCHAR(255),
+    bucket_id    bigint,
+    context      LONGTEXT,
+    created_date datetime(6) not null,
+    updated_date datetime(6) not null,
+    primary key (id),
+    foreign key (bucket_id) references bucket (id)
+);
+
+-- Review Reaction Table
+create table review_reaction (
+    id        bigint not null auto_increment,
+    user_id   bigint,
+    review_id bigint,
+    reaction  varchar(255),
+    primary key (id),
+    foreign key (user_id) references user (id),
+    foreign key (review_id) references review (id)
 );


### PR DESCRIPTION
- 후기 리액션 CRUD 구현
- 기존 ReviewRequestDto를 POST에 쓰일 것과 PUT에 쓰일 것으로 구분
- ReviewResponseDto와 ReviewReactionResponseDto로 구분

Change-Id: I243a27eef738ed6e9746c517aad0344794062cde